### PR TITLE
feat(core): 新增 DateUtil.parseNatural 方法支持自然语言日期时间解析

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
@@ -6,6 +6,7 @@ import cn.hutool.core.date.format.DateParser;
 import cn.hutool.core.date.format.DatePrinter;
 import cn.hutool.core.date.format.FastDateFormat;
 import cn.hutool.core.date.format.GlobalCustomFormat;
+import cn.hutool.core.date.natural.NaturalDateParser;
 import cn.hutool.core.lang.Assert;
 import cn.hutool.core.lang.PatternPool;
 import cn.hutool.core.util.CharUtil;
@@ -45,7 +46,7 @@ public class DateUtil extends CalendarUtil {
 			"jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec", // 月份
 			"gmt", "ut", "utc", "est", "edt", "cst", "cdt", "mst", "mdt", "pst", "pdt"// 时间标准
 	};
-	
+
 	/**
 	 * 匹配日期分隔符（正斜杠、点、年、月），用于统一替换为横杠
 	 */
@@ -2457,5 +2458,50 @@ public class DateUtil extends CalendarUtil {
 		return StrUtil.subBefore(dateStr, before, true)
 				+ before
 				+ millOrNaco + after + StrUtil.subAfter(dateStr, after, true);
+	}
+
+	/**
+	 * 解析自然语言日期时间表达式
+	 * <p>
+	 * 支持以下格式：
+	 * <ul>
+	 *     <li>相对日期：今天、明天、后天、昨天、前天</li>
+	 *     <li>相对日期+时间：明天下午3点、后天上午10点半</li>
+	 *     <li>相对偏移：3天前、5天后、2周前、1个月后</li>
+	 *     <li>星期几：下周一、本周五、上周日</li>
+	 *     <li>星期几+时间：下周一上午9点</li>
+	 *     <li>边界：本月第一天、下个月最后一天、月初、月末</li>
+	 *     <li>时间段：上午、中午、下午、晚上</li>
+	 *     <li>季度：本季度、下季度、上季度</li>
+	 *     <li>年份：今年、明年、去年</li>
+	 *     <li>年月：2026年8月</li>
+	 *     <li>特殊：现在、此刻</li>
+	 * </ul>
+	 *
+	 * @param natural 自然语言日期时间表达式
+	 * @return 解析后的DateTime，无法解析返回null
+	 * @since 6.0.0
+	 */
+	public static DateTime parseNatural(String natural) {
+		return parseNatural(natural, date());
+	}
+
+	/**
+	 * 解析自然语言日期时间表达式（指定基准日期）
+	 *
+	 * @param natural 自然语言日期时间表达式
+	 * @param base    基准日期（相对计算的参考点）
+	 * @return 解析后的DateTime，无法解析返回null
+	 * @since 6.0.0
+	 */
+	public static DateTime parseNatural(String natural, DateTime base) {
+		if (StrUtil.isBlank(natural)) {
+			return null;
+		}
+		if (base == null) {
+			base = date();
+		}
+		DateTime dateTime = NaturalDateParser.parse(natural.trim(), base);
+		return dateTime;
 	}
 }

--- a/hutool-core/src/main/java/cn/hutool/core/date/natural/NaturalDateParser.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/natural/NaturalDateParser.java
@@ -1,0 +1,641 @@
+package cn.hutool.core.date.natural;
+
+import cn.hutool.core.date.DateTime;
+import cn.hutool.core.date.DateUtil;
+import cn.hutool.core.util.StrUtil;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 自然语言日期解析器
+ * 支持：今天/明天/后天、X天前/后、下周一、本月最后一天等
+ *
+ * @author hutool
+ * @since 6.0.0
+ */
+public class NaturalDateParser {
+
+	/**
+	 * 星期映射
+	 */
+	private static final Map<String, DayOfWeek> WEEK_MAP = new HashMap<>();
+	/**
+	 * 相对日期关键词
+	 */
+	private static final Map<String, Integer> RELATIVE_DAY_MAP = new HashMap<>();
+	/**
+	 * 时间段关键词
+	 */
+	private static final Map<String, Integer> DAY_PART_MAP = new HashMap<>();
+	/**
+	 * 边界关键词
+	 */
+	private static final Map<String, String> BOUNDARY_MAP = new HashMap<>();
+
+	static {
+		// 星期映射（支持中文和英文）
+		WEEK_MAP.put("周一", DayOfWeek.MONDAY);
+		WEEK_MAP.put("星期一", DayOfWeek.MONDAY);
+		WEEK_MAP.put("一", DayOfWeek.MONDAY);
+		WEEK_MAP.put("周二", DayOfWeek.TUESDAY);
+		WEEK_MAP.put("星期二", DayOfWeek.TUESDAY);
+		WEEK_MAP.put("二", DayOfWeek.TUESDAY);
+		WEEK_MAP.put("周三", DayOfWeek.WEDNESDAY);
+		WEEK_MAP.put("星期三", DayOfWeek.WEDNESDAY);
+		WEEK_MAP.put("三", DayOfWeek.WEDNESDAY);
+		WEEK_MAP.put("周四", DayOfWeek.THURSDAY);
+		WEEK_MAP.put("星期四", DayOfWeek.THURSDAY);
+		WEEK_MAP.put("四", DayOfWeek.THURSDAY);
+		WEEK_MAP.put("周五", DayOfWeek.FRIDAY);
+		WEEK_MAP.put("星期五", DayOfWeek.FRIDAY);
+		WEEK_MAP.put("五", DayOfWeek.FRIDAY);
+		WEEK_MAP.put("周六", DayOfWeek.SATURDAY);
+		WEEK_MAP.put("星期六", DayOfWeek.SATURDAY);
+		WEEK_MAP.put("六", DayOfWeek.SATURDAY);
+		WEEK_MAP.put("周日", DayOfWeek.SUNDAY);
+		WEEK_MAP.put("星期日", DayOfWeek.SUNDAY);
+		WEEK_MAP.put("天", DayOfWeek.SUNDAY);
+		WEEK_MAP.put("日", DayOfWeek.SUNDAY);
+		WEEK_MAP.put("七", DayOfWeek.SUNDAY);
+
+		// 相对日期偏移（相对于今天）
+		RELATIVE_DAY_MAP.put("今天", 0);
+		RELATIVE_DAY_MAP.put("今日", 0);
+		RELATIVE_DAY_MAP.put("明天", 1);
+		RELATIVE_DAY_MAP.put("明日", 1);
+		RELATIVE_DAY_MAP.put("后天", 2);
+		RELATIVE_DAY_MAP.put("大后天", 3);
+		RELATIVE_DAY_MAP.put("昨天", -1);
+		RELATIVE_DAY_MAP.put("昨日", -1);
+		RELATIVE_DAY_MAP.put("前天", -2);
+		RELATIVE_DAY_MAP.put("大前天", -3);
+
+		// 时间段映射（小时）
+		DAY_PART_MAP.put("凌晨", 0);
+		DAY_PART_MAP.put("早上", 6);
+		DAY_PART_MAP.put("早晨", 6);
+		DAY_PART_MAP.put("上午", 8);
+		DAY_PART_MAP.put("am", 8);
+		DAY_PART_MAP.put("中午", 12);
+		DAY_PART_MAP.put("下午", 13);
+		DAY_PART_MAP.put("pm", 13);
+		DAY_PART_MAP.put("傍晚", 17);
+		DAY_PART_MAP.put("晚上", 19);
+		DAY_PART_MAP.put("夜里", 21);
+		DAY_PART_MAP.put("半夜", 23);
+		DAY_PART_MAP.put("午夜", 0);
+
+		// 边界关键词
+		BOUNDARY_MAP.put("第一天", "FIRST_DAY");
+		BOUNDARY_MAP.put("最后一天", "LAST_DAY");
+		BOUNDARY_MAP.put("第一天", "FIRST_DAY");
+		BOUNDARY_MAP.put("最后一天", "LAST_DAY");
+		BOUNDARY_MAP.put("月初", "FIRST_DAY");
+		BOUNDARY_MAP.put("月末", "LAST_DAY");
+		BOUNDARY_MAP.put("月底", "LAST_DAY");
+		BOUNDARY_MAP.put("年初", "FIRST_DAY");
+		BOUNDARY_MAP.put("年末", "LAST_DAY");
+		BOUNDARY_MAP.put("年底", "LAST_DAY");
+		BOUNDARY_MAP.put("周一", "FIRST_DAY");
+		BOUNDARY_MAP.put("周日", "LAST_DAY");
+	}
+
+	/**
+	 * 解析自然语言日期
+	 *
+	 * @param text 自然语言文本
+	 * @param base 基准日期
+	 * @return 解析后的DateTime，无法解析返回null
+	 */
+	public static DateTime parse(String text, DateTime base) {
+		if (StrUtil.isBlank(text) || base == null) {
+			return null;
+		}
+
+		String trimmed = text.trim();
+
+		// 1. 尝试标准格式（复用DateUtil.parse）
+		try {
+			DateTime result = DateUtil.parse(trimmed);
+			if (result != null) {
+				return result;
+			}
+		} catch (Exception ignored) {
+			// 继续尝试自然语言解析
+		}
+
+		// 2. 按优先级依次尝试匹配
+		NaturalDatePattern[] patterns = NaturalDatePattern.values();
+		for (NaturalDatePattern pattern : patterns) {
+			if (pattern == NaturalDatePattern.STANDARD || pattern == NaturalDatePattern.DEFAULT) {
+				continue;
+			}
+			DateTime result = tryParse(trimmed, base, pattern);
+			if (result != null) {
+				return result;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * 按指定模式尝试解析
+	 */
+	private static DateTime tryParse(String text, DateTime base, NaturalDatePattern pattern) {
+		switch (pattern) {
+			case NOW:
+				return parseNow(text, base);
+			case RELATIVE_DAY:
+				return parseRelativeDay(text, base);
+			case RELATIVE_DAY_TIME:
+				return parseRelativeDayTime(text, base);
+			case RELATIVE_OFFSET:
+				return parseRelativeOffset(text, base);
+			case WEEKDAY:
+				return parseWeekday(text, base);
+			case WEEKDAY_TIME:
+				return parseWeekdayTime(text, base);
+			case BOUNDARY:
+				return parseBoundary(text, base);
+			case DAY_PART:
+				return parseDayPart(text, base);
+			case QUARTER:
+				return parseQuarter(text, base);
+			case YEAR:
+				return parseYear(text, base);
+			case YEAR_MONTH:
+				return parseYearMonth(text, base);
+			default:
+				return null;
+		}
+	}
+
+	// ==================== 各模式解析实现 ====================
+
+	/**
+	 * 解析"现在"、"此刻"、"马上"
+	 */
+	private static DateTime parseNow(String text, DateTime base) {
+		if (matchesAny(text, "现在", "此刻", "马上", "当前", "目前")) {
+			return base;
+		}
+		return null;
+	}
+
+	/**
+	 * 解析相对日期：今天、明天、后天、昨天、前天
+	 */
+	private static DateTime parseRelativeDay(String text, DateTime base) {
+		for (Map.Entry<String, Integer> entry : RELATIVE_DAY_MAP.entrySet()) {
+			if (text.equals(entry.getKey())) {
+				return DateUtil.offsetDay(base, entry.getValue());
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * 解析相对日期+时间：明天下午3点、后天上午10点半
+	 */
+	private static DateTime parseRelativeDayTime(String text, DateTime base) {
+		// 匹配模式：{相对日期}{时间段}{时间}
+		// 如 "明天下午3点" -> 明天 + 下午 + 3点
+		String timePart = null;
+		String dayKey = null;
+
+		// 提取相对日期关键词
+		for (String key : RELATIVE_DAY_MAP.keySet()) {
+			if (text.startsWith(key)) {
+				dayKey = key;
+				timePart = text.substring(key.length());
+				break;
+			}
+		}
+
+		if (dayKey == null || StrUtil.isBlank(timePart)) {
+			return null;
+		}
+
+		// 解析时间
+		DateTime time = parseTimeExpression(timePart, base);
+		if (time == null) {
+			return null;
+		}
+
+		// 应用日期偏移
+		Integer offset = RELATIVE_DAY_MAP.get(dayKey);
+		if (offset == null) {
+			return null;
+		}
+
+		DateTime result = DateUtil.offsetDay(base, offset);
+		// 保留日期部分，应用时间部分
+		return new DateTime(LocalDateTime.of(
+				result.year(),
+				result.month() + 1,
+				result.dayOfMonth(),
+				time.hour(true),
+				time.minute(),
+				time.second()
+		));
+	}
+
+	/**
+	 * 解析相对偏移：3天前、5天后、2周前、1个月后
+	 */
+	private static DateTime parseRelativeOffset(String text, DateTime base) {
+		// 匹配模式：数字 + 单位 + 方向
+		// 支持：天/日、周/星期、月、年、小时、分钟
+		Pattern pattern = Pattern.compile(
+				"^([+-]?\\d+)\\s*个?(天|日|周|星期|月|年|小时|分钟|秒)\\s*(前|后)?$"
+		);
+		Matcher m = pattern.matcher(text);
+		if (!m.find()) {
+			return null;
+		}
+
+		int amount = Integer.parseInt(m.group(1));
+		String unit = m.group(2);
+		String direction = m.group(3);
+
+		// 处理方向
+		if ("前".equals(direction)) {
+			amount = -amount;
+		}
+
+		// 单位转换
+		switch (unit) {
+			case "天":
+			case "日":
+				return DateUtil.offsetDay(base, amount);
+			case "周":
+			case "星期":
+				return DateUtil.offsetWeek(base, amount);
+			case "月":
+				return DateUtil.offsetMonth(base, amount);
+			case "年":
+				return DateUtil.offsetYear(base, amount);
+			case "小时":
+				return DateUtil.offsetHour(base, amount);
+			case "分钟":
+				return DateUtil.offsetMinute(base, amount);
+			case "秒":
+				return DateUtil.offsetSecond(base, amount);
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * 解析星期几：下周一、本周五、上周日
+	 */
+	private static DateTime parseWeekday(String text, DateTime base) {
+		String prefix = null;
+		String weekdayKey = null;
+
+		// 提取前缀（下、本、上）
+		if (text.startsWith("下")) {
+			prefix = "下";
+			weekdayKey = text.substring(1);
+		} else if (text.startsWith("本")) {
+			prefix = "本";
+			weekdayKey = text.substring(1);
+		} else if (text.startsWith("上")) {
+			prefix = "上";
+			weekdayKey = text.substring(1);
+		} else {
+			// 没有前缀，默认本周
+			prefix = "本";
+			weekdayKey = text;
+		}
+
+		// 修正："下下周一" -> "下下" + "周一"
+		if (weekdayKey.startsWith("下") || weekdayKey.startsWith("上") || weekdayKey.startsWith("本")) {
+			// 递归处理多级前缀
+			String subPrefix = weekdayKey.substring(0, 1);
+			String rest = weekdayKey.substring(1);
+			DateTime subResult = parseWeekday(rest, base);
+			if (subResult == null) {
+				return null;
+			}
+			if ("下".equals(subPrefix)) {
+				return DateUtil.offsetWeek(subResult, 1);
+			} else if ("上".equals(subPrefix)) {
+				return DateUtil.offsetWeek(subResult, -1);
+			}
+			return subResult;
+		}
+
+		DayOfWeek target = WEEK_MAP.get(weekdayKey);
+		if (target == null) {
+			return null;
+		}
+
+		LocalDate baseDate = base.toLocalDateTime().toLocalDate();
+		LocalDate resultDate;
+
+		switch (prefix) {
+			case "本":
+				// 本周的指定星期（若已过则取下周）
+				resultDate = baseDate.with(TemporalAdjusters.nextOrSame(target));
+				break;
+			case "下":
+				// 下周的指定星期
+				resultDate = baseDate.with(TemporalAdjusters.next(target));
+				break;
+			case "上":
+				// 上周的指定星期
+				resultDate = baseDate.with(TemporalAdjusters.previous(target));
+				break;
+			default:
+				return null;
+		}
+
+		return new DateTime(resultDate.atStartOfDay());
+	}
+
+	/**
+	 * 解析星期几+时间：下周一上午9点
+	 */
+	private static DateTime parseWeekdayTime(String text, DateTime base) {
+		String weekdayKey = null;
+		String timePart = null;
+		String prefix = null;
+
+		// 提取前缀
+		if (text.startsWith("下") || text.startsWith("本") || text.startsWith("上")) {
+			prefix = text.substring(0, 1);
+			String rest = text.substring(1);
+			// 提取星期关键词
+			for (String key : WEEK_MAP.keySet()) {
+				if (rest.startsWith(key)) {
+					weekdayKey = key;
+					timePart = rest.substring(key.length());
+					break;
+				}
+			}
+		}
+
+		if (weekdayKey == null || StrUtil.isBlank(timePart)) {
+			return null;
+		}
+
+		// 先解析星期
+		String weekdayText = (prefix != null ? prefix : "本") + weekdayKey;
+		DateTime weekdayResult = parseWeekday(weekdayText, base);
+		if (weekdayResult == null) {
+			return null;
+		}
+
+		// 解析时间
+		DateTime time = parseTimeExpression(timePart, base);
+		if (time == null) {
+			return weekdayResult;
+		}
+
+		// 合并日期和时间
+		return new DateTime(LocalDateTime.of(
+				weekdayResult.year(),
+				weekdayResult.month() + 1,
+				weekdayResult.dayOfMonth(),
+				time.hour(true),
+				time.minute(),
+				time.second()
+		));
+	}
+
+	/**
+	 * 解析边界：本月第一天、下个月最后一天、年初、月末
+	 */
+	private static DateTime parseBoundary(String text, DateTime base) {
+		// 提取月份偏移和边界类型
+		int monthOffset = 0;
+		String boundaryType = null;
+		String remaining = text;
+
+		// 处理"下个月"、"上个月"、"本月"
+		if (text.contains("下个月") || text.contains("下月")) {
+			monthOffset = 1;
+			remaining = text.replace("下个月", "").replace("下月", "");
+		} else if (text.contains("上个月") || text.contains("上月")) {
+			monthOffset = -1;
+			remaining = text.replace("上个月", "").replace("上月", "");
+		} else if (text.contains("本月") || text.contains("这个月")) {
+			monthOffset = 0;
+			remaining = text.replace("本月", "").replace("这个月", "");
+		}
+
+		// 提取边界类型
+		if (remaining.contains("第一天") || remaining.contains("月初") || remaining.contains("开始")) {
+			boundaryType = "FIRST_DAY";
+		} else if (remaining.contains("最后一天") || remaining.contains("月末") || remaining.contains("月底") || remaining.contains("结束")) {
+			boundaryType = "LAST_DAY";
+		}
+
+		if (boundaryType == null) {
+			return null;
+		}
+
+		DateTime targetMonth = DateUtil.offsetMonth(base, monthOffset);
+		LocalDate targetDate = targetMonth.toLocalDateTime().toLocalDate();
+
+		LocalDate resultDate;
+		if ("FIRST_DAY".equals(boundaryType)) {
+			resultDate = targetDate.with(TemporalAdjusters.firstDayOfMonth());
+		} else {
+			resultDate = targetDate.with(TemporalAdjusters.lastDayOfMonth());
+		}
+
+		return new DateTime(resultDate.atStartOfDay());
+	}
+
+	/**
+	 * 解析时间段：上午、中午、下午、晚上（基于当前日期）
+	 */
+	private static DateTime parseDayPart(String text, DateTime base) {
+		Integer hour = DAY_PART_MAP.get(text);
+		if (hour == null) {
+			return null;
+		}
+
+		return new DateTime(LocalDateTime.of(
+				base.year(),
+				base.month() + 1,
+				base.dayOfMonth(),
+				hour,
+				0,
+				0
+		));
+	}
+
+	/**
+	 * 解析季度：本季度、下季度、上季度
+	 */
+	private static DateTime parseQuarter(String text, DateTime base) {
+		int offset = 0;
+		if (text.contains("下") || text.contains("下个")) {
+			offset = 1;
+		} else if (text.contains("上") || text.contains("上个")) {
+			offset = -1;
+		} else if (!text.contains("本") && !text.contains("这个")) {
+			return null;
+		}
+
+		DateTime target = DateUtil.offsetMonth(base, offset * 3);
+		LocalDate targetDate = target.toLocalDateTime().toLocalDate();
+		LocalDate quarterStart = targetDate.with(targetDate.getMonth().firstMonthOfQuarter())
+				.with(TemporalAdjusters.firstDayOfMonth());
+		return new DateTime(quarterStart.atStartOfDay());
+	}
+
+	/**
+	 * 解析年份：今年、明年、去年
+	 */
+	private static DateTime parseYear(String text, DateTime base) {
+		int offset = 0;
+		if (text.equals("明年") || text.equals("下年")) {
+			offset = 1;
+		} else if (text.equals("去年") || text.equals("上年")) {
+			offset = -1;
+		} else if (!text.equals("今年") && !text.equals("本年")) {
+			return null;
+		}
+
+		DateTime target = DateUtil.offsetYear(base, offset);
+		return DateUtil.beginOfYear(target);
+	}
+
+	/**
+	 * 解析年月：2026年8月
+	 */
+	private static DateTime parseYearMonth(String text, DateTime base) {
+		Pattern pattern = Pattern.compile("^(\\d{4})\\s*年\\s*(\\d{1,2})\\s*月$");
+		Matcher m = pattern.matcher(text);
+		if (!m.find()) {
+			return null;
+		}
+		int year = Integer.parseInt(m.group(1));
+		int month = Integer.parseInt(m.group(2));
+		return new DateTime(LocalDateTime.of(year, month, 1, 0, 0, 0));
+	}
+
+	/**
+	 * 解析时间表达式：3点、14:30、下午3点半
+	 */
+	private static DateTime parseTimeExpression(String text, DateTime base) {
+		if (StrUtil.isBlank(text)) {
+			return null;
+		}
+
+		// 处理时间段前缀 + 时间
+		String timeText = text;
+		int hourOffset = 0;
+		for (Map.Entry<String, Integer> entry : DAY_PART_MAP.entrySet()) {
+			if (text.startsWith(entry.getKey())) {
+				hourOffset = entry.getValue();
+				timeText = text.substring(entry.getKey().length());
+				break;
+			}
+		}
+
+		// 解析时间数字
+		// 支持：3点、3点半、3:30、3点30分、14:30:15
+		Pattern timePattern = Pattern.compile(
+				"(?i)" + // 忽略大小写
+						"(?:" +
+						// 分支1：标准数字时间（含毫秒）  例：12:30:15.123 或 12点30分15秒123
+						"(?<hour1>\\d{1,2})\\s*[:：点时]\\s*(?<min1>\\d{1,2})(?:\\s*[:：分]\\s*(?<sec1>\\d{1,2})(?:[.。]?(?<milli>\\d+))?\\s*秒?)?|" +
+						// 分支2：中文半/刻  例：3点半、2点一刻、4点三刻
+						"(?<hour2>\\d{1,2})\\s*点\\s*(?<special>半|一[刻]?|二[刻]?|三[刻]?)|" +
+						// 分支3：单独的“X点”  例：5点
+						"(?<hour3>\\d{1,2})\\s*点\\s*" +
+						")"
+		);
+		Matcher m = timePattern.matcher(timeText);
+
+		int hour, minute = 0, second = 0, milli = 0;
+
+		if (m.find()) {
+			// 确定数字小时（从命中的分支提取）
+			if (m.group("hour1") != null) {
+				hour = Integer.parseInt(m.group("hour1"));
+				minute = Integer.parseInt(m.group("min1"));
+				if (m.group("sec1") != null) second = Integer.parseInt(m.group("sec1"));
+				if (m.group("milli") != null) milli = Integer.parseInt(m.group("milli"));
+			} else if (m.group("hour2") != null) {
+				hour = Integer.parseInt(m.group("hour2"));
+				String sp = m.group("special");
+				if ("半".equals(sp) || "二刻".equals(sp)) minute = 30;
+				else if ("一刻".equals(sp)) minute = 15;
+				else if ("三刻".equals(sp)) minute = 45;
+			} else if (m.group("hour3") != null) {
+				hour = Integer.parseInt(m.group("hour3"));
+				minute = 0;
+			} else {
+				return null; // 未匹配
+			}
+		} else {
+			// 尝试纯数字解析：1430 -> 14:30
+			Pattern numPattern = Pattern.compile("^(\\d{1,2})(\\d{2})$");
+			Matcher numMatcher = numPattern.matcher(timeText.trim());
+			if (numMatcher.find()) {
+				hour = Integer.parseInt(numMatcher.group(1));
+				minute = Integer.parseInt(numMatcher.group(2));
+			} else if (timeText.trim().length() == 0 && hourOffset > 0){
+				hour = hourOffset;
+			} else {
+				return null;
+			}
+		}
+
+		// 应用时间段偏移（如"下午3点" -> 15点）
+		if (hourOffset > 12 && hour < 12) {
+			hour += 12;
+		}
+
+		if (hour >= 24) {
+			hour = hour % 24;
+		}
+
+		return new DateTime(LocalDateTime.of(
+				base.year(),
+				base.month() + 1,
+				base.dayOfMonth(),
+				hour,
+				minute,
+				second
+		));
+	}
+
+	/**
+	 * 获取文本中的时间段关键词
+	 */
+	private static String getDayPartKey(String text) {
+		for (String key : DAY_PART_MAP.keySet()) {
+			if (text.contains(key)) {
+				return key;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * 判断文本是否匹配任意关键词
+	 */
+	private static boolean matchesAny(String text, String... keywords) {
+		for (String keyword : keywords) {
+			if (text.equals(keyword)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/hutool-core/src/main/java/cn/hutool/core/date/natural/NaturalDatePattern.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/natural/NaturalDatePattern.java
@@ -1,0 +1,92 @@
+package cn.hutool.core.date.natural;
+
+/**
+ * 自然语言日期模式枚举
+ * 按匹配优先级排序（数值越小优先级越高）
+ *
+ * @author yoran.ye
+ * @since 6.0.0
+ */
+public enum NaturalDatePattern {
+
+	/**
+	 * 纯数字日期时间：2026-08-04 14:30:00（交给DateUtil.parse兜底）
+	 */
+	STANDARD(0, "STANDARD"),
+
+	/**
+	 * 相对日期：今天、明天、后天、昨天、前天
+	 */
+	RELATIVE_DAY(10, "RELATIVE_DAY"),
+
+	/**
+	 * 相对日期+时间：明天下午3点、后天上午10点半
+	 */
+	RELATIVE_DAY_TIME(20, "RELATIVE_DAY_TIME"),
+
+	/**
+	 * 相对偏移：3天前、5天后、2周前、1个月后
+	 */
+	RELATIVE_OFFSET(30, "RELATIVE_OFFSET"),
+
+	/**
+	 * 星期几：下周一、本周五、上周日
+	 */
+	WEEKDAY(40, "WEEKDAY"),
+
+	/**
+	 * 星期几+时间：下周一上午9点
+	 */
+	WEEKDAY_TIME(50, "WEEKDAY_TIME"),
+
+	/**
+	 * 月初/月末/年初/年末：本月第一天、下个月最后一天
+	 */
+	BOUNDARY(60, "BOUNDARY"),
+
+	/**
+	 * 特殊：现在、此刻、马上
+	 */
+	NOW(70, "NOW"),
+
+	/**
+	 * 时间点：上午、中午、下午、晚上、凌晨（基于当前日期）
+	 */
+	DAY_PART(80, "DAY_PART"),
+
+	/**
+	 * 季度：本季度、下季度、上季度
+	 */
+	QUARTER(90, "QUARTER"),
+
+	/**
+	 * 年份：今年、明年、去年
+	 */
+	YEAR(100, "YEAR"),
+
+	/**
+	 * 年月：2026年8月
+	 */
+	YEAR_MONTH(110, "YEAR_MONTH"),
+
+	/**
+	 * 默认（兜底）
+	 */
+	DEFAULT(999, "DEFAULT");
+
+	private final int priority;
+	private final String name;
+
+	NaturalDatePattern(int priority, String name) {
+		this.priority = priority;
+		this.name = name;
+	}
+
+	public int getPriority() {
+		return priority;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/hutool-core/src/test/java/cn/hutool/core/date/DateUtilNaturalTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/DateUtilNaturalTest.java
@@ -1,0 +1,136 @@
+package cn.hutool.core.date;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * 自然语言日期解析测试
+ */
+public class DateUtilNaturalTest {
+
+	/** 基准日期：2026-08-04 10:00:00（周二） */
+	private static final DateTime BASE = new DateTime(LocalDateTime.of(2026, 8, 4, 0, 0, 0));
+
+	@Test
+	public void testParseRelativeDay() {
+		assertEquals("2026-08-04 00:00:00", DateUtil.parseNatural("今天", BASE).toString());
+		assertEquals("2026-08-05 00:00:00", DateUtil.parseNatural("明天", BASE).toString());
+		assertEquals("2026-08-06 00:00:00", DateUtil.parseNatural("后天", BASE).toString());
+		assertEquals("2026-08-03 00:00:00", DateUtil.parseNatural("昨天", BASE).toString());
+		assertEquals("2026-08-02 00:00:00", DateUtil.parseNatural("前天", BASE).toString());
+	}
+
+	@Test
+	public void testParseRelativeDayTime() {
+		DateTime result = DateUtil.parseNatural("明天下午3点", BASE);
+		assertEquals("2026-08-05 15:00:00", result.toString());
+
+		result = DateUtil.parseNatural("后天上午10点半", BASE);
+		assertEquals("2026-08-06 10:30:00", result.toString());
+
+		result = DateUtil.parseNatural("明天中午", BASE);
+		assertEquals("2026-08-05 12:00:00", result.toString());
+
+		result = DateUtil.parseNatural("后天晚上", BASE);
+		assertEquals("2026-08-06 19:00:00", result.toString());
+	}
+
+	@Test
+	public void testParseRelativeOffset() {
+		assertEquals("2026-08-01 00:00:00", DateUtil.parseNatural("3天前", BASE).toString());
+		assertEquals("2026-08-09 00:00:00", DateUtil.parseNatural("5天后", BASE).toString());
+		assertEquals("2026-07-21 00:00:00", DateUtil.parseNatural("2周前", BASE).toString());
+		assertEquals("2026-09-04 00:00:00", DateUtil.parseNatural("1个月后", BASE).toString());
+		assertEquals("2025-08-04 00:00:00", DateUtil.parseNatural("1年前", BASE).toString());
+	}
+
+	@Test
+	public void testParseWeekday() {
+		// 2026-08-04 是周二
+		assertEquals("2026-08-04 00:00:00", DateUtil.parseNatural("本周二", BASE).toString());
+		assertEquals("2026-08-10 00:00:00", DateUtil.parseNatural("下周一", BASE).toString());
+		assertEquals("2026-08-02 00:00:00", DateUtil.parseNatural("上周日", BASE).toString());
+		assertEquals("2026-08-11 00:00:00", DateUtil.parseNatural("下下周二", BASE).toString());
+	}
+
+	@Test
+	public void testParseWeekdayTime() {
+		DateTime result = DateUtil.parseNatural("下周一上午9点", BASE);
+		assertEquals("2026-08-10 09:00:00", result.toString());
+
+		result = DateUtil.parseNatural("本周五下午5点半", BASE);
+		assertEquals("2026-08-07 17:30:00", result.toString());
+	}
+
+	@Test
+	public void testParseBoundary() {
+		assertEquals("2026-08-01 00:00:00", DateUtil.parseNatural("本月第一天", BASE).toString());
+		assertEquals("2026-08-31 00:00:00", DateUtil.parseNatural("本月最后一天", BASE).toString());
+		assertEquals("2026-09-01 00:00:00", DateUtil.parseNatural("下个月第一天", BASE).toString());
+		assertEquals("2026-07-31 00:00:00", DateUtil.parseNatural("上个月最后一天", BASE).toString());
+	}
+
+	@Test
+	public void testParseDayPart() {
+		assertEquals("2026-08-04 08:00:00", DateUtil.parseNatural("上午", BASE).toString());
+		assertEquals("2026-08-04 12:00:00", DateUtil.parseNatural("中午", BASE).toString());
+		assertEquals("2026-08-04 13:00:00", DateUtil.parseNatural("下午", BASE).toString());
+		assertEquals("2026-08-04 19:00:00", DateUtil.parseNatural("晚上", BASE).toString());
+	}
+
+	@Test
+	public void testParseQuarter() {
+		assertEquals("2026-07-01 00:00:00", DateUtil.parseNatural("本季度", BASE).toString());
+		assertEquals("2026-10-01 00:00:00", DateUtil.parseNatural("下季度", BASE).toString());
+		assertEquals("2026-04-01 00:00:00", DateUtil.parseNatural("上季度", BASE).toString());
+	}
+
+	@Test
+	public void testParseYear() {
+		assertEquals("2026-01-01 00:00:00", DateUtil.parseNatural("今年", BASE).toString());
+		assertEquals("2027-01-01 00:00:00", DateUtil.parseNatural("明年", BASE).toString());
+		assertEquals("2025-01-01 00:00:00", DateUtil.parseNatural("去年", BASE).toString());
+	}
+
+	@Test
+	public void testParseYearMonth() {
+		assertEquals("2026-08-01 00:00:00", DateUtil.parseNatural("2026年8月", BASE).toString());
+		assertEquals("2025-12-01 00:00:00", DateUtil.parseNatural("2025年12月", BASE).toString());
+	}
+
+	@Test
+	public void testParseNow() {
+		// 解析"现在"应返回当前时间（基准时间）
+		DateTime now = DateUtil.parseNatural("现在", BASE);
+		assertEquals(BASE.getTime(), now.getTime());
+
+		now = DateUtil.parseNatural("此刻", BASE);
+		assertEquals(BASE.getTime(), now.getTime());
+	}
+
+	@Test
+	public void testParseStandardFormatFallback() {
+		// 标准格式应直接解析
+		assertEquals("2026-08-04 14:30:00",
+				DateUtil.parseNatural("2026-08-04 14:30:00", BASE).toString());
+		assertEquals("2026-08-04 00:00:00",
+				DateUtil.parseNatural("2026/08/04", BASE).toString());
+	}
+
+	@Test
+	public void testParseNull() {
+		assertNull(DateUtil.parseNatural(null));
+		assertNull(DateUtil.parseNatural(""));
+		assertNull(DateUtil.parseNatural("   "));
+	}
+
+	@Test
+	public void testParseUnsupported() {
+		// 不支持的表达式返回null
+		assertNull(DateUtil.parseNatural("无法转换文字", BASE));
+	}
+}


### PR DESCRIPTION
### 📌 背景与需求

在实际开发中，用户常输入“明天下午3点”、“3天前”、“下周一”等自然语言表达来指定日期时间。目前 Hutool 的 `DateUtil` 仅支持标准格式（如 `yyyy-MM-dd HH:mm:ss`），无法处理这类口语化输入，开发者往往需要自行编写正则和逻辑，增加了重复劳动和出错风险。

参考 Joda-Time 的 `DateTimeFormatter` 和 Go 语言的 `parse` 库，为 Hutool 增加自然语言解析能力，可以显著提升易用性，降低业务代码复杂度。

### 🚀 设计方案

#### 核心思路

1. **复用现有 API**：标准格式优先复用 `DateUtil.parse`，相对偏移复用 `DateUtil.offsetXxx` 方法，保证一致性。
2. **优先级匹配**：定义枚举 `NaturalDatePattern`，按优先级从高到低尝试匹配，避免歧义。
3. **独立解析器**：逻辑封装于 `NaturalDateParser` 内部类，保持 `DateUtil` 入口简洁。
4. **兼容性优先**：所有新增方法均为 `static`，不修改现有方法签名；解析失败返回 `null` 而非抛异常，调用方可自行处理。

#### 支持的自然语言格式

| 类别 | 示例 |
|------|------|
| 相对日期 | `今天`、`明天`、`后天`、`昨天`、`前天` |
| 相对日期 + 时间 | `明天下午3点`、`后天上午10点半` |
| 相对偏移 | `3天前`、`5天后`、`2周前`、`1个月后`、`1年前` |
| 星期几 | `本周二`、`下周一`、`上周日`、`下下周二` |
| 星期几 + 时间 | `下周一上午9点`、`本周五下午5点半` |
| 边界 | `本月第一天`、`本月最后一天`、`下个月第一天`、`上个月最后一天` |
| 时间段 | `上午`、`中午`、`下午`、`晚上`、`凌晨` |
| 季度 | `本季度`、`下季度`、`上季度` |
| 年份 | `今年`、`明年`、`去年` |
| 年月 | `2026年8月` |
| 特殊 | `现在`、`此刻` |
| 标准格式（兜底） | `2026-08-04 14:30:00`、`2026/08/04` |

### 📖 使用示例

```java
// 基础用法
DateTime dt = DateUtil.parseNatural("明天下午3点");
// 输出：2026-08-05 15:00:00

// 指定基准日期
DateTime base = DateUtil.parse("2026-08-01");
DateTime dt2 = DateUtil.parseNatural("3天后", base);
// 输出：2026-08-04 00:00:00

// 支持链式组合
DateTime dt3 = DateUtil.parseNatural("下周一上午9点");
// 若当前为2026-08-04（周二），则输出2026-08-10 09:00:00

// 解析失败返回 null
DateTime invalid = DateUtil.parseNatural("随便说说");
Assert.assertNull(invalid);
```

### ✅ 测试覆盖

新增测试类 `DateUtilNaturalTest`，包含 **30+** 个测试用例，覆盖：
- 所有支持的格式类别
- 边界条件（空字符串、null）
- 基准日期偏移验证
- 标准格式兜底解析
- 多级前缀（如下下周一）

测试全部通过，无新增异常。

### 🔄 兼容性说明

- **向后兼容**：不影响任何现有 API，`DateUtil` 仅新增 `parseNatural` 方法。
- **依赖**：仅使用 JDK 8+ 的 `java.time` 和 Hutool 现有工具类（`StrUtil`、`DateUtil` 等），无新增外部依赖。
- **行为**：解析失败返回 `null`，不抛出受检异常，与 Hutool 其他 `parse` 方法风格一致。