### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
     <a href="https://deepwiki.com/chinabugotech/hutool">
         <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki">
     </a>
+<a href="https://inspect.software/software/chinabugotech/hutool"><img src="https://raw.githubusercontent.com/inspect-software/badges/main/v1/c/chinabugotech/hutool.svg" alt="inspect.software score badge for chinabugotech/hutool" /></a>
 </p>
 
 <br/>


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/chinabugotech/hutool), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
