### PR TITLE
Fix typo in FastDatePrinter javadoc

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/format/FastDatePrinter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/format/FastDatePrinter.java
@@ -357,7 +357,7 @@ public class FastDatePrinter extends AbstractDateBasic implements DatePrinter {
 	/**
 	 * Creates a String representation of the given Calendar by applying the rules of this printer to it.
 	 *
-	 * @param c the Calender to apply the rules to.
+	 * @param c the Calendar to apply the rules to.
 	 * @return a String representation of the given Calendar.
 	 */
 	private String applyRulesToString(Calendar c) {


### PR DESCRIPTION
Fix minor typos in comments/javadoc/log messages. No functional change.