### PR TITLE
fix: preserve CSV line numbers after CRLF comments

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/csv/CsvParser.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/csv/CsvParser.java
@@ -252,6 +252,8 @@ public final class CsvParser extends ComputeIter<CsvRow> implements Closeable, S
 					lineNo++;
 					inComment = false;
 				}
+				// 记录注释行的换行符，避免将 CRLF 中的 LF 误认为空行
+				preChar = c;
 				// 跳过注释行中的任何字符
 				continue;
 			}

--- a/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvCommentTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvCommentTest.java
@@ -1,0 +1,99 @@
+package cn.hutool.core.text.csv;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CsvCommentTest {
+
+	@ParameterizedTest
+	@ValueSource(strings = {"\n", "\r", "\r\n"})
+	public void commentsPreserveOriginalLineNumbers(String lineEnd) {
+		final CsvData data = new CsvReader().readFromStr(
+			"# first comment" + lineEnd + "a,b" + lineEnd
+				+ "# second comment" + lineEnd + "# third comment" + lineEnd + "c,d");
+
+		assertEquals(2, data.getRowCount());
+		assertEquals(Arrays.asList("a", "b"), data.getRow(0).getRawList());
+		assertEquals(1, data.getRow(0).getOriginalLineNumber());
+		assertEquals(Arrays.asList("c", "d"), data.getRow(1).getRawList());
+		assertEquals(4, data.getRow(1).getOriginalLineNumber());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"\n", "\r", "\r\n"})
+	public void commentsDoNotCreateEmptyRows(String lineEnd) {
+		final CsvReadConfig config = CsvReadConfig.defaultConfig().setSkipEmptyRows(false);
+		final CsvData data = new CsvReader(config).readFromStr(
+			"# comment" + lineEnd + lineEnd + "a,b" + lineEnd + "# final comment" + lineEnd);
+
+		assertEquals(2, data.getRowCount());
+		assertEquals("", data.getRow(0).get(0));
+		assertEquals(1, data.getRow(0).getOriginalLineNumber());
+		assertEquals(Arrays.asList("a", "b"), data.getRow(1).getRawList());
+		assertEquals(2, data.getRow(1).getOriginalLineNumber());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"\n", "\r", "\r\n"})
+	public void headerAfterCommentUsesOriginalLineNumber(String lineEnd) {
+		final CsvReadConfig config = CsvReadConfig.defaultConfig().setHeaderLineNo(1);
+		final CsvData data = new CsvReader(config).readFromStr(
+			"# comment" + lineEnd + "name,value" + lineEnd + "first,1");
+
+		assertEquals(1, data.getRowCount());
+		assertEquals("first", data.getRow(0).getByName("name"));
+		assertEquals("1", data.getRow(0).getByName("value"));
+		assertEquals(2, data.getRow(0).getOriginalLineNumber());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"\n", "\r", "\r\n"})
+	public void lineRangeAfterCommentUsesOriginalLineNumber(String lineEnd) {
+		final CsvReadConfig config = CsvReadConfig.defaultConfig().setBeginLineNo(2).setEndLineNo(2);
+		final CsvData data = new CsvReader(config).readFromStr(
+			"# comment" + lineEnd + "first,1" + lineEnd + "second,2" + lineEnd + "third,3");
+
+		assertEquals(1, data.getRowCount());
+		assertEquals(Arrays.asList("second", "2"), data.getRow(0).getRawList());
+		assertEquals(2, data.getRow(0).getOriginalLineNumber());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"\n", "\r", "\r\n"})
+	public void commentCharactersInQuotedFieldsArePreserved(String lineEnd) {
+		final CsvData data = new CsvReader().readFromStr(
+			"# comment" + lineEnd + "\"first" + lineEnd + "# still a field\",1" + lineEnd + "last,2");
+
+		assertEquals(2, data.getRowCount());
+		assertEquals("first" + lineEnd + "# still a field", data.getRow(0).get(0));
+		assertEquals(1, data.getRow(0).getOriginalLineNumber());
+		assertEquals(3, data.getRow(1).getOriginalLineNumber());
+	}
+
+	@Test
+	public void customCommentCharacterWithMixedLineEndings() {
+		final CsvReadConfig config = CsvReadConfig.defaultConfig().setCommentCharacter(';');
+		final CsvData data = new CsvReader(config).readFromStr("; first\r\n; second\n; third\ra,b\r\n");
+
+		assertEquals(1, data.getRowCount());
+		assertEquals(Arrays.asList("a", "b"), data.getRow(0).getRawList());
+		assertEquals(3, data.getRow(0).getOriginalLineNumber());
+	}
+
+	@Test
+	public void disabledCommentsRemainData() {
+		final CsvReadConfig config = CsvReadConfig.defaultConfig().disableComment();
+		final CsvData data = new CsvReader(config).readFromStr("# first\r\n# second\r\n");
+
+		assertEquals(2, data.getRowCount());
+		assertEquals("# first", data.getRow(0).get(0));
+		assertEquals(0, data.getRow(0).getOriginalLineNumber());
+		assertEquals("# second", data.getRow(1).get(0));
+		assertEquals(1, data.getRow(1).getOriginalLineNumber());
+	}
+}


### PR DESCRIPTION
### 说明

- 目标分支为 `v5-dev`，保持 tab 缩进。
- 仅修改 CSV 注释解析状态并补充回归测试，不新增 API 或依赖。

### 问题与修复

`CsvParser.readLine()` 跳过注释字符时没有更新 `preChar`。注释以 `\r\n` 结束时，虽然 `\r` 已计入行号，后续的 `\n` 仍可能被当作一个额外的空行。这会导致：

- 后续记录的 `getOriginalLineNumber()` 偏大；
- `setSkipEmptyRows(false)` 读取到不存在的空行；
- 按原始行号选择范围时返回错误记录；
- 按原始行号指定注释后的表头时，无法初始化表头并触发 `NullPointerException`。

修复是在注释分支也维护前一个字符，让现有 CRLF 合并逻辑正常生效。

最小复现（原始行号从 0 开始）：

```java
CsvReadConfig config = CsvReadConfig.defaultConfig()
    .setBeginLineNo(2).setEndLineNo(2);
CsvData data = new CsvReader(config).readFromStr(
    "# comment\r\nfirst,1\r\nsecond,2\r\nthird,3");
// 修复前为 [first, 1]；修复后为 [second, 2]
System.out.println(data.getRow(0).getRawList());
```

Related: #3947。新增测试使用明确包含 LF、CR、CRLF 的内存字符串，不依赖 Git 检出时的换行符转换。

### 提交前自测

环境：Windows 11 x64、Temurin JDK 8u504、Maven 3.9.9。

- 修复前：17 个新增回归用例中，11 个通过、5 个断言失败、1 个表头空指针异常。
- 修复后：17 个新增用例全部通过，覆盖原始行号、真实/虚假空行、表头、行范围、引号内注释字符、自定义注释字符和禁用注释。
- 文本处理测试目录：152 个用例，138 个通过、14 个原有禁用测试，0 failures / 0 errors。

```sh
mvn -pl hutool-core -am '-Dtest=cn/hutool/core/text/**/*Test' -Dsurefire.failIfNoSpecifiedTests=false test
mvn -pl hutool-core -am -Dmaven.test.skip=true package
```

第二条命令成功生成 core JAR 和 Javadoc JAR；打包步骤跳过测试，测试结果来自第一条命令。未运行其他模块或整个 core 的测试集。用于既有文件测试的 CSV 样例保持仓库提交中的原始字节，没有样例文件变更。

本 PR 使用 Codex 辅助定位、实现和编写测试；以上结果来自本地实际执行。
