### PR TITLE
Fix typo in FastDatePrinter javadoc

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/format/FastDatePrinter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/format/FastDatePrinter.java
@@ -357,7 +357,7 @@ public class FastDatePrinter extends AbstractDateBasic implements DatePrinter {
 	/**
 	 * Creates a String representation of the given Calendar by applying the rules of this printer to it.
 	 *
-	 * @param c the Calender to apply the rules to.
+	 * @param c the Calendar to apply the rules to.
 	 * @return a String representation of the given Calendar.
 	 */
 	private String applyRulesToString(Calendar c) {


### PR DESCRIPTION
## Summary

Fix a typo in the Javadoc for `FastDatePrinter.applyRulesToString()`.

- `the Calender to apply the rules to.` -> `the Calendar to apply the rules to.`

No functional change. Resubmitted to `v5-dev` per maintainer feedback (previous #4320 was closed for targeting `v5-master`).

Closes #4320 (originally closed by maintainer; same fix, new base branch).